### PR TITLE
SchemaCreation has changed namespace

### DIFF
--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module Redshift
-      class SchemaCreation < AbstractAdapter::SchemaCreation
+      class SchemaCreation < SchemaCreation
         private
 
         def visit_ColumnDefinition(o)


### PR DESCRIPTION
In Rails 6, `ActiveRecord::ConnectionAdapters::AbstractAdapter::SchemaCreation` was renamed to `ActiveRecord::ConnectionAdapters::SchemaCreation`. See https://github.com/rails/rails/pull/37187/files.