### PR TITLE
Add optional keyword arguments

### DIFF
--- a/lib/active_record/connection_adapters/redshift/column.rb
+++ b/lib/active_record/connection_adapters/redshift/column.rb
@@ -4,7 +4,7 @@ module ActiveRecord
       delegate :oid, :fmod, to: :sql_type_metadata
       attr_reader :primary_key, :primary_key_index, :redshift_distribution_key, :redshift_sort_key_order, :redshift_column_encoding
 
-      def initialize(name, default, sql_type_metadata, null = true, default_function = nil, is_primary_key = false, column_index = nil, primary_key_order = nil, is_dist_key = false, sort_key_order = 0, col_encoding = nil)
+      def initialize(name, default, sql_type_metadata, null = true, default_function = nil, is_primary_key = false, column_index = nil, primary_key_order = nil, is_dist_key = false, sort_key_order = 0, col_encoding = nil, **)
         super name, default, sql_type_metadata, null, default_function
         @primary_key = is_primary_key
         if is_primary_key && primary_key_order


### PR DESCRIPTION
In Rails 6.1, `Column.new` is assumed to receive an optional keyword argument. 

See https://github.com/rails/rails/commit/91712c5080cce23457f1f0e1e6dc7635f869b515#diff-38b55a4f9c4fea6b4bcc55597c963ad594c893f7957c09f4ae9177239e3f1ca5.